### PR TITLE
Sort directories returned by os.walk

### DIFF
--- a/hydeengine/file_system.py
+++ b/hydeengine/file_system.py
@@ -583,6 +583,7 @@ class Folder(FileSystemEntity):
                 visitor.visit_complete()
 
         for root, dirs, a_files in os.walk(self.path):
+            dirs.sort()
             folder = Folder(root)
             if not __visit_folder__(visitor, folder):
                 dirs[:] = []


### PR DESCRIPTION
When Python returns directories from os.walk (which uses os.listdir),
they are in an arbitrary order on some OSes (Ubuntu, etc) per the Python
documentation. Adding a .sort() in the process resolves this issue,
ensuring that directories are sorted properly and processed in the
correct order.
